### PR TITLE
Fixed `CalendarPresenter` and documentation

### DIFF
--- a/src/main/java/com/courseApp/calendarService/CalendarPresenter.java
+++ b/src/main/java/com/courseApp/calendarService/CalendarPresenter.java
@@ -83,6 +83,7 @@ public class CalendarPresenter implements ControlCalendarPresentation {
                 resultingCalendar += headerGenerator(Constants.WINTER_TERM);
                 resultingCalendar += winterCalendar.present();
             }
+            default -> throw new IllegalStateException("Unexpected value: " + termType);
         }
         return resultingCalendar;
     }
@@ -97,22 +98,35 @@ public class CalendarPresenter implements ControlCalendarPresentation {
      */
     public String presentCalendar(String termType, String calendarType,
                                   Map<String, Map<String, ArrayList<String>>> rawSchedule){
+
+        // Check calendar type
+        UsePresentable fallCalendar;
+        UsePresentable winterCalendar;
+        if (calendarType.equals(Constants.TYPE_WORKDAY)){
+            fallCalendar = new WorkdayCalendar(scheduleProcessor(Constants.FALL_TERM, rawSchedule));
+            winterCalendar = new WorkdayCalendar(scheduleProcessor(Constants.WINTER_TERM, rawSchedule));
+        }
+        else{
+            return Constants.CALENDAR_TYPE_ERROR;
+        }
         String resultingCalendar = "";
         resultingCalendar += headerGenerator(termType);
-        // Check calendar type
-        if (calendarType.equals(Constants.TYPE_WORKDAY)){
-            WorkdayCalendar fallCalendar = new WorkdayCalendar(scheduleProcessor(Constants.FALL_TERM, rawSchedule));
-            WorkdayCalendar winterCalendar = new WorkdayCalendar(scheduleProcessor(Constants.WINTER_TERM, rawSchedule));
-            resultingCalendar += typeDecorator(fallCalendar, winterCalendar, termType, rawSchedule);
-        }
+        resultingCalendar += typeDecorator(fallCalendar, winterCalendar, termType, rawSchedule);
         return resultingCalendar;
     }
 
-
 //    public static void main(String[] args) {
-//        CalendarPresenter cad;
+//        CalendarPresenter cad = new CalendarPresenter();
+//        Map<String, Map<String, ArrayList<String>>> rawSchedule = new HashMap<>();
+//        Map<String, ArrayList<String>> course = new HashMap<>();
+//        ArrayList<String> array = new ArrayList<>();
+//        array.add("13:00-14:00");
+//        course.put("MO", array);
+//        rawSchedule.put("BIO230FLEC9901", course);
+//        System.out.println(cad.presentCalendar("W", "Workday", rawSchedule));
 //
 //        UserServiceController USC2 = new UserServiceController();
+//        USC2.userRegister("USC2", "1234567890");
 //
 //
 ////        USC2.userClearCourseList("USC2");
@@ -127,6 +141,5 @@ public class CalendarPresenter implements ControlCalendarPresentation {
 //
 //        cad = new CalendarPresenter();
 //
-//        System.out.println(cad.presentCalendar("Y", "Workday", USC2.getLatestSchedule("USC2").getScheduleMap()));
 //    }
 }

--- a/src/main/java/com/courseApp/calendarService/CalendarPresenter.java
+++ b/src/main/java/com/courseApp/calendarService/CalendarPresenter.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.courseApp.constants.Exceptions;
 import com.courseApp.courseService.CourseServiceController;
 import com.courseApp.entity.Schedule;
 import com.courseApp.userService.UserServiceController;
@@ -83,7 +84,7 @@ public class CalendarPresenter implements ControlCalendarPresentation {
                 resultingCalendar += headerGenerator(Constants.WINTER_TERM);
                 resultingCalendar += winterCalendar.present();
             }
-            default -> throw new IllegalStateException("Unexpected value: " + termType);
+            default -> throw new IllegalStateException(Exceptions.WRONG_TERM_TYPE);
         }
         return resultingCalendar;
     }
@@ -107,7 +108,7 @@ public class CalendarPresenter implements ControlCalendarPresentation {
             winterCalendar = new WorkdayCalendar(scheduleProcessor(Constants.WINTER_TERM, rawSchedule));
         }
         else{
-            return Constants.CALENDAR_TYPE_ERROR;
+            return Exceptions.WRONG_CALENDAR_TYPE;
         }
         String resultingCalendar = "";
         resultingCalendar += headerGenerator(termType);

--- a/src/main/java/com/courseApp/constants/Constants.java
+++ b/src/main/java/com/courseApp/constants/Constants.java
@@ -35,6 +35,8 @@ public class Constants {
     public static final String YEAR_HEADER = "Calendar of the Year\n";
     public static final String FALL_HEADER = "Calendar of the Fall Term\n";
     public static final String WINTER_HEADER = "Calendar of the Winter Term\n";
+    public static final String CALENDAR_TYPE_ERROR = "The calendar type is invalid.";
+    public static final String TERM_TYPE_ERROR = "The Term type is invalid.";
 
 
 

--- a/src/main/java/com/courseApp/constants/Constants.java
+++ b/src/main/java/com/courseApp/constants/Constants.java
@@ -35,8 +35,6 @@ public class Constants {
     public static final String YEAR_HEADER = "Calendar of the Year\n";
     public static final String FALL_HEADER = "Calendar of the Fall Term\n";
     public static final String WINTER_HEADER = "Calendar of the Winter Term\n";
-    public static final String CALENDAR_TYPE_ERROR = "The calendar type is invalid.";
-    public static final String TERM_TYPE_ERROR = "The Term type is invalid.";
 
 
 

--- a/src/main/java/com/courseApp/constants/Exceptions.java
+++ b/src/main/java/com/courseApp/constants/Exceptions.java
@@ -2,7 +2,9 @@ package com.courseApp.constants;
 
 public class Exceptions {
     public static final String WRONG_COURSE_CODE_FORMAT = "The course code format is incorrect.";
-    public static final String  NO_SECTION_CODE = "The section code is not provided ControlPresentInfo the course code.";
+    public static final String NO_SECTION_CODE = "The section code is not provided ControlPresentInfo the course code.";
     public static final String NO_EXISTING_SCHEDULE = "There is no possible schedule for these courses.";
     public static final String COMMAND_NOT_FOUND = "No such command.";
+    public static final String WRONG_CALENDAR_TYPE = "The calendar type is invalid.";
+    public static final String WRONG_TERM_TYPE = "The term type is invalid.";
 }

--- a/teamDocumentation/CalendarServiceDocumentation.md
+++ b/teamDocumentation/CalendarServiceDocumentation.md
@@ -25,7 +25,7 @@ in the `CalendarPresenter` class.
     - `"S"` for winter term, 
     - `"Y"` for both of  terms, please be aware that it gives **two** calendars.
 
-  - You can choose different format arguing `calendarType`, so for instant, `"WorkDay"` is the only available choice as we have only implemented this subclass, `WorkdayCalendar`. 
+  - You can choose different format arguing `calendarType`, so for instant, `"Workday"` is the only available choice as we have only implemented this subclass, `WorkdayCalendar`. 
 
 
 - The rest of the code are functional, but they will not be accessed or used directly by users.


### PR DESCRIPTION
- This pull request fixes issue #44 
- In the `presentCalendar` method:
  - If statement positioning fixed to avoid duplicate code.
  - Else statement added to identify unexpected types.
- Documentation typo fixed
- Error message put in 'Exceptions`.